### PR TITLE
Along with selfLink, use apiVersion, kind, name, and namespace for deletion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "temptifly",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "temptifly",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Side-by-side template editor",
   "main": "dist/index.js",
   "scripts": {

--- a/src/utils/refresh-source-from-stack.js
+++ b/src/utils/refresh-source-from-stack.js
@@ -165,7 +165,11 @@ const mergeSource = (
   // filter out the custom resources that don't exist in the current template using selfLinks
   customResources = customResources.filter(resource => {
     // filter out custom resource that isn't in next version of template
-    const selfLink = _.get(resource, 'metadata.selfLink')
+
+    const deleteLink = _.merge(
+      _.pick(resource, ['apiVersion', 'kind']),
+      _.pick(_.get(resource, 'metadata', {}), ['selfLink', 'name', 'namespace'])
+    )
     let resourceID = getResourceID(resource)
     if (!resourceID) {
       return false
@@ -190,9 +194,7 @@ const mergeSource = (
       if (inx === -1) {
         // if editor got rid of it, add to the selfLinks we will be deleting
         // when updating editor to server
-        if (selfLink) {
-          deletedLinks.add(selfLink)
-        }
+        deletedLinks.add(deleteLink)
         return false
       } else {
         // else remove from currentTemplateResources such that


### PR DESCRIPTION
Port changes from `carbon_components` branch.