### PR TITLE
Allow passing arbitrary props to custom components

### DIFF
--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -53,6 +53,7 @@ const Portals = Object.freeze({
 export default class TemplateEditor extends React.Component {
   static propTypes = {
     controlData: PropTypes.array.isRequired,
+    controlProps: PropTypes.object,
     createControl: PropTypes.shape({
       hasPermissions: PropTypes.bool,
       createResource: PropTypes.func,
@@ -452,6 +453,7 @@ export default class TemplateEditor extends React.Component {
         onChange={this.props.onControlChange}
         onStepChange={this.props.onStepChange}
         templateYAML={this.state.templateYAML}
+        controlProps={this.props.controlProps}
       />
     )
   }

--- a/src/controls/ControlPanel.js
+++ b/src/controls/ControlPanel.js
@@ -33,6 +33,7 @@ import {
 class ControlPanel extends React.Component {
   static propTypes = {
     controlData: PropTypes.array,
+    controlProps: PropTypes.object,
     fetchData: PropTypes.object,
     handleCancelCreate: PropTypes.func,
     handleControlChange: PropTypes.func,
@@ -467,7 +468,7 @@ class ControlPanel extends React.Component {
   };
 
   renderControl(id, type, control, grpId) {
-    const { controlData, showEditor, isLoaded, i18n, templateYAML, handleCreateResource } = this.props
+    const { controlData, showEditor, isLoaded, i18n, templateYAML, handleCreateResource, controlProps } = this.props
     if (this.isHidden(control, controlData)) {
       return null
     }
@@ -624,7 +625,7 @@ class ControlPanel extends React.Component {
     case 'custom':
       return (
         <React.Fragment key={controlId}>
-          {this.renderCustom(control, controlId, templateYAML, handleCreateResource)}
+          {this.renderCustom(control, controlId, templateYAML, handleCreateResource, controlProps)}
         </React.Fragment>
       )
     }
@@ -635,7 +636,7 @@ class ControlPanel extends React.Component {
     control.ref = ref
   };
 
-  renderCustom(control, controlId, templateYAML, handleCreateResource) {
+  renderCustom(control, controlId, templateYAML, handleCreateResource, controlProps) {
     const { i18n } = this.props
     const { component } = control
     const custom = React.cloneElement(component, {
@@ -644,7 +645,8 @@ class ControlPanel extends React.Component {
       controlId,
       handleChange: this.handleChange.bind(this, control),
       templateYAML,
-      handleCreateResource
+      handleCreateResource,
+      controlProps,
     })
     return (
       <React.Fragment>


### PR DESCRIPTION
as title says, we can pass arbirary props from `TemplateEditor` parent to custom component. Parent component may have a state or any other info that we need to access from custom component like https://github.com/open-cluster-management/console/blob/main/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx#L72 